### PR TITLE
README copy edits and questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
-# C2PA Android Example
+# C2PA Android example app
 
-This repository contains a prototype Android application demonstrating how to capture photos and videos and sign them with C2PA (Content Authenticity Initiative) credentials.
+The [c2pa-android-example repository](https://github.com/contentauth/c2pa-android-example) contains a prototype Android application demonstrating how to capture photos and videos, embed Content Credentials, and then sign them.
+
 The app is built using modern Android development practices with Jetpack Compose and CameraX.
 
 ## Key Features
-- Photo & Video Capture: Uses CameraX for a robust camera implementation.
-- C2PA Signing: Signs captured media with RSA keys to create a C2PA manifest, ensuring content authenticity.
-- In- Place Signing: Correctly handles modern Android Scoped Storage by signing files from content:// URIs in- place using a temporary file strategy.
-- Location Tagging: Fetches the device's current location and embeds it into the C2PA manifest.
-- Video Recording Control: Supports starting, pausing, resuming, and stopping video recordings, with the UI reacting to the current state.
-- Runtime Permissions: Gracefully handles camera, audio, and location permissions.
 
-## Tech Stack & Core Libraries
+- **Photo and video capture**: Uses CameraX for a robust camera implementation.
+- **C2PA signing**: Signs captured media with RSA keys to create a C2PA manifest, ensuring content authenticity.
+- **In-place signing**: Correctly handles modern Android Scoped Storage by signing files from `content://` URIs in-place using a temporary file strategy.
+- **Location tagging**: Fetches the device's current location and embeds it into the C2PA manifest.
+- **Video recording control**: Supports starting, pausing, resuming, and stopping video recordings, with the UI reacting to the current state.
+- **Runtime permissions**: Gracefully handles camera, audio, and location permissions.
+
+## Tech stack and core libraries
 
 - UI: 100% Jetpack Compose for a declarative and modern UI.
-- Architecture: MVVM (Model-View-ViewModel).- Dependency Injection: Hilt for managing dependencies.
+- Architecture: MVVM (Model-View-ViewModel).
+- Dependency Injection: Hilt for managing dependencies.
 - Camera: CameraX for camera operations, including preview, image capture, and video capture.
 - Content Authenticity: C2PA Android Library for creating and embedding authenticity manifests.
 - Asynchronicity: Kotlin Coroutines and Flow for managing background tasks and reactive data streams.
@@ -24,41 +27,47 @@ The app is built using modern Android development practices with Jetpack Compose
 - MapLibre Compose: For showing location of captured media.
 
 ## Project Architecture
+
 The application's logic is centered around a few key files that demonstrate a clean separation of concerns.
 
-### 1. UI Layer (/ui)
+### UI layer (/ui)
 
-**[CameraScreen.kt](./app/src/main/java/com/proofmode/c2pa/ui/CameraScreen.kt)**:
+**[CameraScreen.kt](https://github.com/contentauth/c2pa-android-example/blob/main/app/src/main/java/com/proofmode/c2pa/ui/CameraScreen.kt)**:
+
 - The main entry point for the camera UI.
 - Handles all runtime permission requests (Camera, Audio, Location).
-- Displays either a permission request screen or the main CameraCaptureScreen.
-- CameraCaptureScreen (within CameraScreen.kt):
-- Observes state from CameraViewModel (recordingState, thumbPreviewUri).
-- Displays the CameraXViewfinder for the live camera preview.Provides IconButton controls for taking photos, starting/pausing/resuming/stopping video, and navigating to a media preview.
-- The thumbnail preview dynamically updates by observing the thumbPreviewUri StateFlow.
+- Displays either a permission request screen or the main `CameraCaptureScreen`.
+- `CameraCaptureScreen` (within `CameraScreen.kt`):
+  - Observes state from `CameraViewModel` (`recordingState`, `thumbPreviewUri`).
+  - Displays the `CameraXViewfinder` for the live camera preview. Provides `IconButton` controls for taking photos, starting/pausing/resuming/stopping video, and navigating to a media preview.
+  - The thumbnail preview dynamically updates by observing `StateFlow` of the `thumbPreviewUri`.
 
-### 2. ViewModel Layer (/ui)
+### ViewModel layer (/ui)
 
-**[CameraViewModel.kt](./app/src/main/java/com/proofmode/c2pa/ui/CameraViewModel.kt):**
+**[CameraViewModel.kt](https://github.com/contentauth/c2pa-android-example/blob/main/app/src/main/java/com/proofmode/c2pa/ui/CameraViewModel.kt):**
+
 - The core of the application's logic, acting as the bridge between the UI and the data/domain layers.
-- Manages the camera's lifecycle via bindToCamera.- Handles user actions like takePhoto() and captureVideo().
-- Manages the recording state through the RecordingState sealed class, exposing it as a StateFlow for the UI to observe.
-- Fetches the device's location using getCurrentLocation() before a capture.
-- After a capture is saved, it triggers the signWithC2PA() function. 
+- Manages the camera's lifecycle via `bindToCamera`.
+- Handles user actions like `takePhoto()` and `captureVideo()`.
+- Manages the recording state through the `RecordingState` sealed class, exposing it as a `StateFlow` for the UI to observe.
+- Fetches the device's location using `getCurrentLocation()` before a capture.
+- After a capture is saved, it triggers the `signWithC2PA()` function. 
 
-### 3. C2PA Signing Logic (/c2pa)
+### C2PA Signing logic (/c2pa)
 
 **[Utils.kt](./app/src/main/java/com/proofmode/c2pa/c2pa/Utils.kt):**
-- Contains the signWithC2PA() function, which is the heart of the content signing process.
-- Scoped Storage Solution: To sign a file from a content:// URI, it first creates a temporary file in the app's cache, signs that file in-place, and then writes the modified (signed) file back to the original URI.
-- Constructs the C2PA manifest, adding claims for the action (c2pa.created), software agent, and location data.
-- Configures the SignerInfo object using RSA keys stored locally as PEM files.
 
-### 3. General Utilities (/utils)
+- Contains the `signWithC2PA()` function, which is the heart of the content signing process.
+- Scoped Storage Solution: To sign a file from a `content://` URI, it first creates a temporary file in the app's cache, signs that file in-place, and then writes the modified (signed) file back to the original URI.
+- Constructs the C2PA manifest, adding claims for the action (`c2pa.created`), software agent, and location data.
+- Configures the `SignerInfo` object using RSA keys stored locally as PEM files.
 
-**[Utils.kt](./app/src/main/java/com/proofmode/c2pa/utils/Utils.kt)**:
-- getOrGenerateKeyPair(), saveKeyToPem(), etc.: A set of functions for generating an RSA KeyPair and saving it to disk in the standard PEM format.
-- readPemString(): A robust function to read PEM files, correctly stripping headers/footers.
-- getCurrentLocation(): A suspend function that uses the Fused Location Provider to fetch the device's location one time.
-- getMediaFlow(): A function that queries the Android MediaStore to retrieve all photos and videos created by the app, exposing them as a Kotlin Flow.
+### General utilities (/utils)
+
+**[Utils.kt](https://github.com/contentauth/c2pa-android-example/blob/main/app/src/main/java/com/proofmode/c2pa/utils/Utils.kt)**:
+
+- `getOrGenerateKeyPair()`, `saveKeyToPem()`, etc.: A set of functions for generating an RSA KeyPair and saving it to disk in the standard PEM format.
+- `readPemString()`: A robust function to read PEM files, correctly stripping headers/footers.
+- `getCurrentLocation()`: A suspend function that uses the Fused Location Provider to fetch the device's location one time.
+- `getMediaFlow()`: A function that queries the Android MediaStore to retrieve all photos and videos created by the app, exposing them as a Kotlin Flow.
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ The application's logic is centered around a few key files that demonstrate a cl
 
 **[CameraScreen.kt](https://github.com/contentauth/c2pa-android-example/blob/main/app/src/main/java/com/proofmode/c2pa/ui/CameraScreen.kt)**:
 
-- The main entry point for the camera UI.
-- Handles all runtime permission requests (Camera, Audio, Location).
-- Displays either a permission request screen or the main `CameraCaptureScreen`.
-- `CameraCaptureScreen` (within `CameraScreen.kt`):
+The main entry point for the camera UI that handles all runtime permission requests (Camera, Audio, Location):
+- Displays either a permission request screen or the main `CameraCaptureScreen` that:
   - Observes state from `CameraViewModel` (`recordingState`, `thumbPreviewUri`).
   - Displays the `CameraXViewfinder` for the live camera preview. Provides `IconButton` controls for taking photos, starting/pausing/resuming/stopping video, and navigating to a media preview.
   - The thumbnail preview dynamically updates by observing `StateFlow` of the `thumbPreviewUri`.
@@ -46,18 +44,18 @@ The application's logic is centered around a few key files that demonstrate a cl
 
 **[CameraViewModel.kt](https://github.com/contentauth/c2pa-android-example/blob/main/app/src/main/java/com/proofmode/c2pa/ui/CameraViewModel.kt):**
 
-- The core of the application's logic, acting as the bridge between the UI and the data/domain layers.
+The core of the application's logic; acts as the bridge between the UI and the data/domain layers and:
 - Manages the camera's lifecycle via `bindToCamera`.
 - Handles user actions like `takePhoto()` and `captureVideo()`.
 - Manages the recording state through the `RecordingState` sealed class, exposing it as a `StateFlow` for the UI to observe.
 - Fetches the device's location using `getCurrentLocation()` before a capture.
-- After a capture is saved, it triggers the `signWithC2PA()` function. 
+- After a capture is saved, it triggers the `signMediaFile()` function. 
 
-### C2PA Signing logic (/c2pa)
+### C2PA signing logic (/c2pa_signing)
 
-**[Utils.kt](./app/src/main/java/com/proofmode/c2pa/c2pa/Utils.kt):**
+**[Utils.kt](https://github.com/contentauth/c2pa-android-example/blob/main/app/src/main/java/com/proofmode/c2pa/c2pa_signing/C2PAManager.kt):**
 
-- Contains the `signWithC2PA()` function, which is the heart of the content signing process.
+Contains the `signMediaFile()` function, which is the heart of the content signing process:
 - Scoped Storage Solution: To sign a file from a `content://` URI, it first creates a temporary file in the app's cache, signs that file in-place, and then writes the modified (signed) file back to the original URI.
 - Constructs the C2PA manifest, adding claims for the action (`c2pa.created`), software agent, and location data.
 - Configures the `SignerInfo` object using RSA keys stored locally as PEM files.


### PR DESCRIPTION
This PR is mostly for some simple copy edits to the README, including spelling, capitalization, formatting, and changing relative URLs in liks to absolute URLs so they work in the doc site as well as in GH.

However, the README has a broken link to a source file and refers to some functions that are no longer in the source.... so I have questions:
- FIXED The **C2PA Signing logic** section links to a non-existent file https://github.com/contentauth/c2pa-android-example/blob/main/app/src/main/java/com/proofmode/c2pa/c2pa/Utils.kt.  What should this link be? 
- FIXED The **ViewModel** and C2PA Signing logic sections refer to the `signWithC2PA()` function which does not exist in the codebase.  What is the correct function?
- The **General utilities** section refers to some functions that don't exist in the source code.  What are the correct functions?
  - `getOrGenerateKeyPair()`
  - `saveKeyToPem()`
  - `readPemString()` 